### PR TITLE
Change clang to gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,65 @@
-# code-server: https://github.com/cdr/code-server
-# docker-code-server: https://github.com/linuxserver/docker-code-server
+## code-server: https://github.com/cdr/code-server
+## docker-code-server: https://github.com/linuxserver/docker-code-server
 
-# 30-08-2021: VS Code 1.57.1 (latest version is 1.59.0)
-FROM ghcr.io/linuxserver/code-server:latest
+## 17-09-2021: code-server 3.12.0 - VS Code 1.60 : unable to launch C++ debugger
+#FROM ghcr.io/linuxserver/code-server:version-v3.12.0
+# VS Code 1.57.1
+FROM ghcr.io/linuxserver/code-server:version-v3.11.1
 
-# Do not start as a service
+## Do not start as a service
 RUN rm -r /etc/services.d/code-server
 
-# First install needed tools
+## We need add-apt-repository
 RUN apt-get update && \
-    apt-get -y install lsb-release \
-                       software-properties-common \
-                       cmake \
-                       curl \
-                       git \
-                       sudo \
-                       wget
+    apt-get -y install software-properties-common
 
 # Setup c++ development
 
-## # USE ONLY clang++
-## # gcc-11
-## # From https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test
-## RUN add-apt-repository ppa:ubuntu-toolchain-r/test
-## RUN apt-get update
-## RUN apt-get install -y gcc-11 g++-11
+## gcc-11
+## From https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN apt-get update
+RUN apt-get install -y gcc-11 g++-11
 
+RUN update-alternatives \
+  --install /usr/bin/gcc                 gcc                  /usr/bin/gcc-11     100 \
+  --slave   /usr/bin/g++                 g++                  /usr/bin/g++-11
+
+RUN update-alternatives \
+  --install /usr/bin/c++                 c++                  /usr/bin/g++        100
+
+## Will install gcc-7
+# RUN apt-get install -y cmake
+RUN curl -L -o /tmp/cmake-3.21.2-linux-x86_64.tar.gz https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-linux-x86_64.tar.gz
+RUN tar --directory=/usr --strip-components=1 -xzf /tmp/cmake-3.21.2-linux-x86_64.tar.gz
+RUN rm /tmp/cmake-3.21.2-linux-x86_64.tar.gz
+
+## USE ONLY g++
 # clang-13
 # From https://apt.llvm.org
-RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+#RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 
-# Other tools and libs
+## USE ONLY g++
+# llvm 12.0.1 https://github.com/llvm/llvm-project/releases
+# it includes libc++ (apt.llvm.org does not)
+# RUN wget https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+# RUN tar --directory=/usr/local --strip-components=1 -xJf clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+# RUN rm clang+llvm-12.0.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+
+## Other tools and libs
 RUN apt-get install -y gdb \
                        googletest \
-                       libboost-dev
+                       libboost-dev \
+                       make \
+                       wget
+
+## Build googletest with installed compiler
+RUN mkdir -p /tmp/gtest
+WORKDIR /tmp/gtest
+RUN cmake /usr/src/googletest/googletest
+RUN make install
+WORKDIR /
+RUN rm -r /tmp/gtest
 
 # Package libtbb-dev is too old for parallel C++ algorithms
 RUN wget -O /tmp/oneapi-tbb.tgz https://github.com/oneapi-src/oneTBB/releases/download/v2021.3.0/oneapi-tbb-2021.3.0-lin.tgz
@@ -43,7 +69,9 @@ RUN mv /opt/oneapi-tbb-2021.3.0 /opt/tbb
 
 # Install VSCode extensions
 RUN code-server --extensions-dir /config/extensions --install-extension ms-vscode.cpptools
-# 30-08-2021: 1.6.0 needs VS Code 1.58.0 or later
+## 1.6.0 for VS Code 1.58.0 or later
+#RUN curl -L -o /tmp/cpptools-linux.vsix https://github.com/microsoft/vscode-cpptools/releases/download/1.6.0/cpptools-linux.vsix
+## 1.5.1 for VS Code 1.53.0 or later
 RUN curl -L -o /tmp/cpptools-linux.vsix https://github.com/microsoft/vscode-cpptools/releases/download/1.5.1/cpptools-linux.vsix
 RUN code-server --extensions-dir /config/extensions --install-extension /tmp/cpptools-linux.vsix
 RUN rm /tmp/cpptools-linux.vsix
@@ -64,41 +92,6 @@ RUN git clone --branch master --single-branch --depth 1 \
         /config/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
 RUN sed -i 's/plugins=(.*/plugins=(git vscode)/' /config/.zshrc
 
-# Default c++20
-
-## # USE ONLY clang++
-## # /usr/bin/g++ is a direct link to /usr/bin/g++-7
-## RUN rm /usr/bin/g++
-## RUN update-alternatives \
-##   --install /usr/bin/gcc                 gcc                  /usr/bin/gcc-11     10 \
-##   --slave   /usr/bin/g++                 g++                  /usr/bin/g++-11
-## RUN update-alternatives \
-##   --install /usr/bin/gcc                 gcc                  /usr/bin/gcc-7       5 \
-##   --slave   /usr/bin/g++                 g++                  /usr/bin/g++-7
-
-RUN update-alternatives \
-  --install /usr/bin/c++                   c++                    /usr/bin/clang++-13   100
-
-RUN update-alternatives \
-  --install /usr/bin/clang                 clang                  /usr/bin/clang-13     100 \
-  --slave   /usr/bin/clang++               clang++                /usr/bin/clang++-13 \
-  --slave   /usr/bin/lld                   lld                    /usr/bin/lld-13 \
-  --slave   /usr/bin/clang-format          clang-format           /usr/bin/clang-format-13  \
-  --slave   /usr/bin/clang-tidy            clang-tidy             /usr/bin/clang-tidy-13 \
-  --slave   /usr/bin/clang-tools           clang-tools            /usr/bin/clang-tools-13 \
-  --slave   /usr/bin/lldb                  lldb                   /usr/bin/lldb-13 \
-  --slave   /usr/bin/clangd                clangd                 /usr/bin/clangd-13
-
-# build googletest
-RUN mkdir -p /tmp/gtest
-WORKDIR /tmp/gtest
-RUN cmake /usr/src/googletest/googletest
-RUN make install
-WORKDIR /
-RUN rm -r /tmp/gtest
-
-## # USE ONLY clang++
-## RUN echo alias g++=\"g++ -std=c++20\"         >>/config/.zshrc
 RUN echo source /opt/tbb/env/vars.sh          >>/config/.zshrc
 RUN mkdir -p /config/workspace/.vscode
 COPY c_cpp_properties.json /config/workspace/.vscode/

--- a/c_cpp_properties.json
+++ b/c_cpp_properties.json
@@ -6,10 +6,10 @@
                 "${workspaceFolder}/**"
             ],
             "defines": [],
-            "compilerPath": "/usr/bin/clang",
+            "compilerPath": "/usr/bin/gcc",
             "cStandard": "c11",
             "cppStandard": "c++20",
-            "intelliSenseMode": "linux-clang-x64",
+            "intelliSenseMode": "${default}",
             "compilerArgs": [
                 "-std=c++20"
             ]

--- a/tasks.json
+++ b/tasks.json
@@ -3,7 +3,7 @@
         {
             "type": "cppbuild",
             "label": "C++20: build active file",
-            "command": "/usr/bin/clang++",
+            "command": "/usr/bin/g++",
             "args": [
                 "-std=c++20",
                 "-g",


### PR DESCRIPTION
Fail to install recent libc++ to be used by clang++. And libstdc++ on bionic is too old. Switch to g++-11 with a libstdc++ compliant to C++ 2020 standard.

Try also to switch to code-server 3.12.0, but fail to debug a C++ program => back to code-server 3.11.1.